### PR TITLE
Note scale slider & fix material replacement color being washed out

### DIFF
--- a/CustomNotes/Managers/CustomBombController.cs
+++ b/CustomNotes/Managers/CustomBombController.cs
@@ -1,12 +1,15 @@
 ﻿using Zenject;
 using UnityEngine;
 using CustomNotes.Data;
+using CustomNotes.Settings.Utilities;
 using SiraUtil.Objects;
 
 namespace CustomNotes.Managers
 {
     internal class CustomBombController : MonoBehaviour
     {
+        private PluginConfig _pluginConfig;
+
         private CustomNote _customNote;
         private NoteMovement _noteMovement;
         private BombNoteController _bombNoteController;
@@ -18,8 +21,10 @@ namespace CustomNotes.Managers
         protected SiraPrefabContainer.Pool bombPool;
 
         [Inject]
-        internal void Init(NoteAssetLoader noteAssetLoader, [Inject(Id = "cn.bomb")] SiraPrefabContainer.Pool bombContainerPool)
+        internal void Init(PluginConfig pluginConfig, NoteAssetLoader noteAssetLoader, [Inject(Id = "cn.bomb")] SiraPrefabContainer.Pool bombContainerPool)
         {
+            _pluginConfig = pluginConfig;
+
             _customNote = noteAssetLoader.CustomNoteObjects[noteAssetLoader.SelectedNote];
             _bombNoteController = GetComponent<BombNoteController>();
             _noteMovement = GetComponent<NoteMovement>();
@@ -49,7 +54,7 @@ namespace CustomNotes.Managers
             container.transform.SetParent(bombMesh);
             fakeMesh.transform.localPosition = container.transform.localPosition = new Vector3(0.0f, 0.0f, 0.0f);
             container.transform.localRotation = Quaternion.identity;
-            fakeMesh.transform.localScale = new Vector3(0.4f, 0.4f, 0.4f);
+            fakeMesh.transform.localScale = new Vector3(0.4f, 0.4f, 0.4f) * _pluginConfig.NoteSize;
             container.transform.localScale = Vector3.one;
         }
 

--- a/CustomNotes/Managers/CustomNoteController.cs
+++ b/CustomNotes/Managers/CustomNoteController.cs
@@ -4,12 +4,15 @@ using SiraUtil.Objects;
 using CustomNotes.Data;
 using SiraUtil.Interfaces;
 using CustomNotes.Overrides;
+using CustomNotes.Settings.Utilities;
 using CustomNotes.Utilities;
 
 namespace CustomNotes.Managers
 {
     public class CustomNoteController : MonoBehaviour, IColorable
     {
+        private PluginConfig _pluginConfig;
+
         protected Transform noteCube;
         private CustomNote _customNote;
         private GameNoteController _gameNoteController;
@@ -27,12 +30,14 @@ namespace CustomNotes.Managers
         public Color Color => _customNoteColorNoteVisuals != null ? _customNoteColorNoteVisuals.noteColor : Color.white;
 
         [Inject]
-        internal void Init(NoteAssetLoader noteAssetLoader,
+        internal void Init(PluginConfig pluginConfig,
+            NoteAssetLoader noteAssetLoader,
             [Inject(Id = "cn.left.arrow")] SiraPrefabContainer.Pool leftArrowNotePool,
             [Inject(Id = "cn.right.arrow")] SiraPrefabContainer.Pool rightArrowNotePool,
             [InjectOptional(Id = "cn.left.dot")] SiraPrefabContainer.Pool leftDotNotePool,
             [InjectOptional(Id = "cn.right.dot")] SiraPrefabContainer.Pool rightDotNotePool)
-        {            
+        {
+            _pluginConfig = pluginConfig;
             _leftArrowNotePool = leftArrowNotePool;
             _rightArrowNotePool = rightArrowNotePool;
 
@@ -87,7 +92,7 @@ namespace CustomNotes.Managers
             container.transform.SetParent(noteCube);
             fakeMesh.transform.localPosition = container.transform.localPosition = new Vector3(0.0f, 0.0f, 0.0f);
             container.transform.localRotation = Quaternion.identity;
-            fakeMesh.transform.localScale = new Vector3(0.4f, 0.4f, 0.4f);
+            fakeMesh.transform.localScale = new Vector3(0.4f, 0.4f, 0.4f) * _pluginConfig.NoteSize;
             container.transform.localScale = Vector3.one;
         }
 
@@ -115,6 +120,10 @@ namespace CustomNotes.Managers
             if (_customNote.Descriptor.DisableBaseNoteArrows)
             {
                 _customNoteColorNoteVisuals.TurnOffVisuals();
+            }
+            else if(_pluginConfig.NoteSize != 1)
+            {
+                _customNoteColorNoteVisuals.ScaleVisuals(_pluginConfig.NoteSize);
             }
         }
 

--- a/CustomNotes/Overrides/CustomNoteColorNoteVisuals.cs
+++ b/CustomNotes/Overrides/CustomNoteColorNoteVisuals.cs
@@ -36,5 +36,17 @@ namespace CustomNotes.Overrides
             _arrowGlowSpriteRenderer.enabled = false;
             _circleGlowSpriteRenderer.enabled = false;
         }
+
+        public void ScaleVisuals(float scale)
+        {
+            Vector3 scaleVector = new Vector3(1, 1, 1) * scale;
+            _arrowMeshRenderer.gameObject.transform.localScale = scaleVector;
+            _arrowGlowSpriteRenderer.gameObject.transform.localScale = scaleVector;
+            _circleGlowSpriteRenderer.gameObject.transform.localScale = scaleVector;
+
+            _arrowMeshRenderer.gameObject.transform.localPosition = new Vector3(0, 0.11f, -0.25f) * scale;
+            _arrowGlowSpriteRenderer.gameObject.transform.localPosition = new Vector3(0, 0.11f, -0.25f) * scale;
+            _circleGlowSpriteRenderer.gameObject.transform.localPosition = new Vector3(0, 0, -0.25f) * scale;
+        }
     }
 }

--- a/CustomNotes/Properties/AssemblyInfo.cs
+++ b/CustomNotes/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.2")]
-[assembly: AssemblyFileVersion("2.0.2")]
+[assembly: AssemblyVersion("2.1.0")]
+[assembly: AssemblyFileVersion("2.1.0")]

--- a/CustomNotes/Providers/CustomGameNoteProvider.cs
+++ b/CustomNotes/Providers/CustomGameNoteProvider.cs
@@ -30,6 +30,10 @@ namespace CustomNotes.Providers
                     MaterialSwapper.ReplaceMaterialsForGameObject(note.NoteRight);
                     MaterialSwapper.ReplaceMaterialsForGameObject(note.NoteDotLeft);
                     MaterialSwapper.ReplaceMaterialsForGameObject(note.NoteDotRight);
+                    Utils.AddMaterialPropertyBlockController(note.NoteLeft);
+                    Utils.AddMaterialPropertyBlockController(note.NoteRight);
+                    Utils.AddMaterialPropertyBlockController(note.NoteDotLeft);
+                    Utils.AddMaterialPropertyBlockController(note.NoteDotRight);
                     Container.BindMemoryPool<SiraPrefabContainer, SiraPrefabContainer.Pool>().WithId("cn.left.arrow").WithInitialSize(25).FromComponentInNewPrefab(NotePrefabContainer(note.NoteLeft));
                     Container.BindMemoryPool<SiraPrefabContainer, SiraPrefabContainer.Pool>().WithId("cn.right.arrow").WithInitialSize(25).FromComponentInNewPrefab(NotePrefabContainer(note.NoteRight));
                     if (note.NoteDotLeft != null)

--- a/CustomNotes/Settings/UI/NoteDetailsViewController.cs
+++ b/CustomNotes/Settings/UI/NoteDetailsViewController.cs
@@ -1,14 +1,22 @@
 ﻿using HMUI;
 using CustomNotes.Data;
 using CustomNotes.Utilities;
+using CustomNotes.Managers;
+using CustomNotes.Settings.Utilities;
 using BeatSaberMarkupLanguage.Attributes;
 using BeatSaberMarkupLanguage.ViewControllers;
+using Zenject;
+using System;
+using CustomNotes.Settings.UI;
 
 namespace CustomNotes.Settings
 {
     internal class NoteDetailsViewController : BSMLResourceViewController
     {
         public override string ResourceName => "CustomNotes.Settings.UI.Views.noteDetails.bsml";
+
+        private PluginConfig _pluginConfig;
+        private NoteListViewController _listViewController;
 
         [UIComponent("note-description")]
         public TextPageScrollView noteDescription = null;
@@ -22,6 +30,25 @@ namespace CustomNotes.Settings
             else
             {
                 noteDescription.SetText(string.Empty);
+            }
+        }
+
+        [Inject]
+        public void Construct(PluginConfig pluginConfig, NoteListViewController listViewController)
+        {
+            _pluginConfig = pluginConfig;
+            _listViewController = listViewController;
+        }
+
+
+        [UIValue("note-size")]
+        public float noteSize
+        {
+            get { return _pluginConfig.NoteSize; }
+            set 
+            { 
+                _pluginConfig.NoteSize = value;
+                _listViewController.ScalePreviewNotes(value);
             }
         }
     }

--- a/CustomNotes/Settings/UI/NoteListViewController.cs
+++ b/CustomNotes/Settings/UI/NoteListViewController.cs
@@ -218,6 +218,7 @@ namespace CustomNotes.Settings.UI
             if (noteObject && vector != null)
             {
                 noteObject.transform.localPosition = vector;
+                noteObject.transform.localScale *= _pluginConfig.NoteSize;
             }
         }
 
@@ -248,6 +249,26 @@ namespace CustomNotes.Settings.UI
                 Destroy(gameObject);
                 gameObject = null;
             }
+        }
+        
+        private void ScalePreviewNote(GameObject note, float scale)
+        {
+            if (note)
+            {
+                note.transform.localScale = new Vector3(1,1,1) * scale;
+            }
+        }
+        public void ScalePreviewNotes(float scale)
+        {
+            ScalePreviewNote(noteLeft, scale);
+            ScalePreviewNote(noteDotLeft, scale);
+            ScalePreviewNote(noteRight, scale);
+            ScalePreviewNote(noteDotRight, scale);
+
+            ScalePreviewNote(fakeLeftArrow, scale);
+            ScalePreviewNote(fakeLeftDot, scale);
+            ScalePreviewNote(fakeRightArrow, scale);
+            ScalePreviewNote(fakeRightDot, scale);
         }
     }
 }

--- a/CustomNotes/Settings/UI/NoteListViewController.cs
+++ b/CustomNotes/Settings/UI/NoteListViewController.cs
@@ -264,6 +264,7 @@ namespace CustomNotes.Settings.UI
             ScalePreviewNote(noteDotLeft, scale);
             ScalePreviewNote(noteRight, scale);
             ScalePreviewNote(noteDotRight, scale);
+            ScalePreviewNote(noteBomb, scale);
 
             ScalePreviewNote(fakeLeftArrow, scale);
             ScalePreviewNote(fakeLeftDot, scale);

--- a/CustomNotes/Settings/UI/Views/noteDetails.bsml
+++ b/CustomNotes/Settings/UI/Views/noteDetails.bsml
@@ -5,4 +5,5 @@
   <horizontal pref-width='100' pref-height='45'>
     <text-page id='note-description' />
   </horizontal>
+  <slider-setting text='Note Scale' min='0.4' max='2' increment='0.01' value='note-size' apply-on-change='true'/>
 </vertical>

--- a/CustomNotes/Settings/UI/Views/noteDetails.bsml
+++ b/CustomNotes/Settings/UI/Views/noteDetails.bsml
@@ -5,5 +5,5 @@
   <horizontal pref-width='100' pref-height='45'>
     <text-page id='note-description' />
   </horizontal>
-  <slider-setting text='Note Scale' min='0.4' max='2' increment='0.01' value='note-size' apply-on-change='true'/>
+  <slider-setting text='Note Scale' min='0.5' max='2' increment='0.01' value='note-size' apply-on-change='true'/>
 </vertical>

--- a/CustomNotes/Settings/UI/Views/noteDetails.bsml
+++ b/CustomNotes/Settings/UI/Views/noteDetails.bsml
@@ -2,8 +2,8 @@
   <horizontal bg='panel-top' pad-left='10' pad-right='10' horizontal-fit='PreferredSize'>
     <text text='Note Description' align='Center' font-size='10' />
   </horizontal>
-  <horizontal pref-width='100' pref-height='45'>
+  <horizontal pref-width='100' pref-height='30'>
     <text-page id='note-description' />
   </horizontal>
-  <slider-setting text='Note Scale' min='0.5' max='2' increment='0.01' value='note-size' apply-on-change='true'/>
+  <slider-setting text='Note Scale' min='0.4' max='2' increment='0.05' value='note-size' apply-on-change='true'/>
 </vertical>

--- a/CustomNotes/Settings/Utilities/PluginConfig.cs
+++ b/CustomNotes/Settings/Utilities/PluginConfig.cs
@@ -3,5 +3,7 @@
     public class PluginConfig
     {
         public virtual string LastNote { get; set; }
+
+        public virtual float NoteSize { get; set; } = 1;
     }
 }

--- a/CustomNotes/Utilities/Utils.cs
+++ b/CustomNotes/Utilities/Utils.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using UnityEngine;
 using System.Reflection;
 using System.Collections.Generic;
+using IPA.Utilities;
 
 namespace CustomNotes.Utilities
 {
@@ -68,6 +69,33 @@ namespace CustomNotes.Utilities
                         childRenderer.material.SetColor("_Color", noteColor);
                     }
                 }
+            }
+            MaterialPropertyBlockController materialPropertyBlockController = noteObject.GetComponent<MaterialPropertyBlockController>(); // Set the color of material property block controllers, for the replaced note shader
+            if (materialPropertyBlockController != null)
+            {
+                materialPropertyBlockController.materialPropertyBlock.SetColor("_Color", noteColor);
+                materialPropertyBlockController.ApplyChanges();
+            }
+        }
+
+        /// <summary>
+        /// Adds a MaterialPropertyBlockController to the root of the gameObject. Only selects renderers with specific shaders.
+        /// </summary>
+        /// <param name="gameObject"></param>
+        public static void AddMaterialPropertyBlockController(GameObject gameObject)
+        {
+            List<Renderer> rendererList = new List<Renderer>();
+            foreach (Renderer renderer in gameObject.GetComponentsInChildren<Renderer>())
+            {
+                if (renderer.material.shader.name.ToLower() == "custom/notehd") // only get the replaced note shader
+                {
+                    rendererList.Add(renderer);
+                }
+            }
+            if (rendererList.Count > 0)
+            {
+                MaterialPropertyBlockController newController = gameObject.AddComponent<MaterialPropertyBlockController>();
+                ReflectionUtil.SetField<MaterialPropertyBlockController, Renderer[]>(newController, "_renderers", rendererList.ToArray());
             }
         }
 

--- a/CustomNotes/manifest.json
+++ b/CustomNotes/manifest.json
@@ -9,7 +9,7 @@
   "icon": "CustomNotes.Resources.Icons.icon.png",
   "id": "Custom Notes",
   "name": "CustomNotes",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "dependsOn": {
     "BSIPA": "^4.1.3",
     "BeatSaberMarkupLanguage": "^1.3.5",


### PR DESCRIPTION
- Added note scale slider to the left panel with a range of 0.4x-2.0x (does not change hitboxes)
- Fixed a long running bug that caused notes using the default note shader to look "washed out"
- Fixed a few color-related bugs
