### PR TITLE
Automatically disable custom notes on noodle maps or with incompatible modifiers in use

### DIFF
--- a/CustomNotes/Installers/CustomNotesGameInstaller.cs
+++ b/CustomNotes/Installers/CustomNotesGameInstaller.cs
@@ -18,6 +18,7 @@ namespace CustomNotes.Installers
             {
                 Container.BindInterfacesAndSelfTo<GameCameraManager>().AsSingle();
                 Container.Bind<IInitializable>().To<CustomNoteManager>().AsSingle();
+                Container.Bind<CustomNoteManager.Flags>().AsSingle();
             }
         }
     }

--- a/CustomNotes/Installers/CustomNotesMenuInstaller.cs
+++ b/CustomNotes/Installers/CustomNotesMenuInstaller.cs
@@ -16,7 +16,7 @@ namespace CustomNotes.Installers
             Container.Bind<NoteDetailsViewController>().FromNewComponentAsViewController().AsSingle();
             Container.Bind<NoteListViewController>().FromNewComponentAsViewController().AsSingle();
             Container.BindInterfacesAndSelfTo<NoteModifierViewController>().AsSingle();
-            Container.BindFlowCoordinator<NotesFlowCoordinator>();
+            Container.Bind<NotesFlowCoordinator>().FromNewComponentOnNewGameObject(nameof(NotesFlowCoordinator)).AsSingle();
 
             Container.BindInterfacesTo<MenuButtonManager>().AsSingle();
             Container.BindInterfacesTo<CustomNotesViewManager>().AsSingle();

--- a/CustomNotes/Managers/CustomBombController.cs
+++ b/CustomNotes/Managers/CustomBombController.cs
@@ -24,17 +24,15 @@ namespace CustomNotes.Managers
         protected SiraPrefabContainer container;
         protected SiraPrefabContainer.Pool bombPool;
 
+        private bool _eventsRegistered = false;
+
         [Inject]
         internal void Init(PluginConfig pluginConfig, NoteAssetLoader noteAssetLoader, CustomNoteManager.Flags customNoteFlags, [InjectOptional(Id = "cn.bomb")] SiraPrefabContainer.Pool bombContainerPool)
         {
             _pluginConfig = pluginConfig;
             _customNoteFlags = customNoteFlags;
 
-            if(_customNoteFlags.ForceDisable)
-            {
-                Destroy(this);
-                return;
-            }
+            
 
             _customNote = noteAssetLoader.CustomNoteObjects[noteAssetLoader.SelectedNote];
             bombPool = bombContainerPool;
@@ -42,20 +40,28 @@ namespace CustomNotes.Managers
             _bombNoteController = GetComponent<BombNoteController>();
             _noteMovement = GetComponent<NoteMovement>();
 
-            if(bombPool != null)
-            {
-                _bombNoteController.didInitEvent.Add(this);
-                _noteMovement.noteDidFinishJumpEvent += DidFinish;
-            }
+            
             
             bombMesh = gameObject.transform.Find("Mesh");
             
 
             _bombMeshRenderer = GetComponentInChildren<MeshRenderer>();
 
-            if ((_pluginConfig.HMDOnly || LayerUtils.HMDOverride))
+            if (_customNoteFlags.ForceDisable)
             {
-                if(bombPool == null)
+                return;
+            }
+
+            SetupCustomBomb();
+        }
+
+        protected virtual void SetupCustomBomb()
+        {
+            DeOrRegisterEvents(true);
+
+            if (_pluginConfig.HMDOnly || LayerUtils.HMDOverride)
+            {
+                if (bombPool == null)
                 {
                     // create fake bombs for Custom Notes without Custom Bombs
                     fakeFirstPersonBombMesh = UnityEngine.Object.Instantiate(bombMesh.gameObject);
@@ -65,7 +71,7 @@ namespace CustomNotes.Managers
                     fakeFirstPersonBombMesh.transform.localScale = Vector3.one;
                     fakeFirstPersonBombMesh.transform.localPosition = Vector3.zero;
                     fakeFirstPersonBombMesh.transform.rotation = Quaternion.identity;
-                    fakeFirstPersonBombMesh.layer = (int)LayerUtils.NoteLayer.FirstPerson;
+                    fakeFirstPersonBombMesh.layer = (int) LayerUtils.NoteLayer.FirstPerson;
                 }
             }
             else if (bombPool != null)
@@ -74,18 +80,54 @@ namespace CustomNotes.Managers
             }
         }
 
+        protected virtual void RevertToDefaultBomb()
+        {
+            DeOrRegisterEvents(false);
+
+            if (fakeFirstPersonBombMesh != null)
+            {
+                fakeFirstPersonBombMesh.SetActive(false);
+            }
+            _bombMeshRenderer.enabled = true;
+        }
+
+        protected virtual void DeOrRegisterEvents(bool register)
+        {
+            if (_eventsRegistered == register || bombPool == null) return;
+
+            _eventsRegistered = register;
+
+            if (register)
+            {
+                _bombNoteController.didInitEvent.Add(this);
+                _noteMovement.noteDidFinishJumpEvent += DidFinish;
+                return;
+            }
+
+            if (_bombNoteController != null)
+            {
+                _bombNoteController.didInitEvent.Remove(this);
+            }
+            if (_noteMovement != null)
+            {
+                _noteMovement.noteDidFinishJumpEvent -= DidFinish;
+            }
+        }
+
         private void DidFinish()
         {
+            if (_customNoteFlags.ForceDisable || container == null) return;
+
             container.transform.SetParent(null);
             bombPool.Despawn(container);
+            container = null;
         }
 
         public void HandleNoteControllerDidInit(NoteController noteController)
         {
             if(_customNoteFlags.ForceDisable)
             {
-                _bombMeshRenderer.enabled = true;
-                Destroy(this);
+                RevertToDefaultBomb();
                 return;
             }
             SpawnThenParent(bombPool);
@@ -119,10 +161,7 @@ namespace CustomNotes.Managers
 
         protected void OnDestroy()
         {
-            if (_bombNoteController != null)
-            {
-                _bombNoteController.didInitEvent.Remove(this);
-            }
+            DeOrRegisterEvents(false);
             Destroy(fakeFirstPersonBombMesh);
         }
     }

--- a/CustomNotes/Managers/CustomNoteController.cs
+++ b/CustomNotes/Managers/CustomNoteController.cs
@@ -29,6 +29,8 @@ namespace CustomNotes.Managers
         private SiraPrefabContainer.Pool _leftArrowNotePool;
         private SiraPrefabContainer.Pool _rightArrowNotePool;
 
+        private bool _eventsRegistered = false;
+
         public Color Color => _customNoteColorNoteVisuals != null ? _customNoteColorNoteVisuals.noteColor : Color.white;
 
         [Inject]
@@ -43,15 +45,6 @@ namespace CustomNotes.Managers
             _pluginConfig = pluginConfig;
             _customNoteFlags = customNoteFlags;
 
-            if (_customNoteFlags.ForceDisable || (_customNoteFlags.GhostNotesEnabled && _customNoteFlags.FirstFrameCount != 0 && _customNoteFlags.FirstFrameCount != Time.frameCount))
-            {
-                // Don't set up if it's forcefully disabled or
-                // if Ghost Notes are enabled and this note is not part of the first set of notes
-                // (for late spawning notes when the pool has to bee expanded)
-                Destroy(this);
-                return;
-            }
-
             _leftArrowNotePool = leftArrowNotePool;
             _rightArrowNotePool = rightArrowNotePool;
 
@@ -63,14 +56,25 @@ namespace CustomNotes.Managers
             _gameNoteController = GetComponent<GameNoteController>();
             _customNoteColorNoteVisuals = gameObject.AddComponent<CustomNoteColorNoteVisuals>();
 
-            _gameNoteController.didInitEvent.Add(this);
-            _gameNoteController.noteWasMissedEvent.Add(this);
-            _gameNoteController.noteWasCutEvent.Add(this);
-            _customNoteColorNoteVisuals.didInitEvent += Visuals_DidInit;
-
             noteCube = _gameNoteController.gameObject.transform.Find("NoteCube");
 
             _noteMesh = GetComponentInChildren<MeshRenderer>();
+
+            if (_customNoteFlags.ShouldDisableCustomNote())
+            {
+                // Don't set up if it's forcefully disabled or
+                // if Ghost Notes are enabled and this note is not part of the first set of notes
+                // (for late spawning notes when the pool has to be expanded)
+                return;
+            }
+
+            SetupCustomNote();
+        }
+
+        protected virtual void SetupCustomNote()
+        {
+            DeOrRegisterEvents(true);
+
             if (_pluginConfig.HMDOnly == false && LayerUtils.HMDOverride == false)
             {
                 // only disable if custom notes display on both hmd and display
@@ -79,6 +83,41 @@ namespace CustomNotes.Managers
             else
             {
                 _noteMesh.gameObject.layer = (int) LayerUtils.NoteLayer.ThirdPerson;
+            }
+        }
+
+        protected virtual void RevertToDefaultNote()
+        {
+            DeOrRegisterEvents(false);
+
+            _noteMesh.forceRenderingOff = false;
+            _noteMesh.gameObject.layer = (int) LayerUtils.NoteLayer.Note;
+        }
+
+        protected virtual void DeOrRegisterEvents(bool register)
+        {
+            if (_eventsRegistered == register) return;
+
+            _eventsRegistered = register;
+
+            if (register)
+            {
+                _gameNoteController.didInitEvent.Add(this);
+                _gameNoteController.noteWasMissedEvent.Add(this);
+                _gameNoteController.noteWasCutEvent.Add(this);
+                _customNoteColorNoteVisuals.didInitEvent += Visuals_DidInit;
+                return;
+            }
+
+            if (_gameNoteController != null)
+            {
+                _gameNoteController.didInitEvent.Remove(this);
+                _gameNoteController.noteWasMissedEvent.Remove(this);
+                _gameNoteController.noteWasCutEvent.Remove(this);
+            }
+            if (_customNoteColorNoteVisuals != null)
+            {
+                _customNoteColorNoteVisuals.didInitEvent -= Visuals_DidInit;
             }
         }
 
@@ -107,30 +146,10 @@ namespace CustomNotes.Managers
 
         public void HandleNoteControllerDidInit(NoteController noteController)
         {
-            if(_customNoteFlags.ForceDisable
-                || (_customNoteFlags.GhostNotesEnabled
-                    && (_pluginConfig.HMDOnly || LayerUtils.HMDOverride)))
+            if(_customNoteFlags.ShouldDisableCustomNote())
             {
-                // revert any changes made and destroy the controller
-                _noteMesh.forceRenderingOff = false;
-                _noteMesh.gameObject.layer = (int) LayerUtils.NoteLayer.Note;
-                Destroy(this);
+                RevertToDefaultNote();
                 return;
-            }
-            if(_customNoteFlags.GhostNotesEnabled)
-            {
-                if (_customNoteFlags.FirstFrameCount == 0)
-                {
-                    _customNoteFlags.FirstFrameCount = Time.frameCount;
-                }
-                else if(_customNoteFlags.FirstFrameCount != Time.frameCount)
-                {
-                    // Disable all but the first set of spawned custom notes
-                    _noteMesh.forceRenderingOff = false;
-                    _noteMesh.gameObject.layer = (int) LayerUtils.NoteLayer.Note;
-                    Destroy(this);
-                    return;
-                }
             }
             var data = noteController.noteData;
             SpawnThenParent(data.colorType == ColorType.ColorA
@@ -174,12 +193,10 @@ namespace CustomNotes.Managers
 
         private void Visuals_DidInit(ColorNoteVisuals visuals, NoteController noteController)
         {
-            if (_customNoteFlags.ForceDisable
-                || (_customNoteFlags.GhostNotesEnabled
-                    && _customNoteFlags.FirstFrameCount != 0
-                    && _customNoteFlags.FirstFrameCount != Time.frameCount)
-                || (_customNoteFlags.GhostNotesEnabled
-                    && (_pluginConfig.HMDOnly || LayerUtils.HMDOverride))) return;
+            if (_customNoteFlags.ShouldDisableCustomNote())
+            {
+                return;
+            }
             SetActiveThenColor(activeNote, visuals.noteColor);
             // Hide certain parts of the default note which is not required
             if(_pluginConfig.HMDOnly == false && LayerUtils.HMDOverride == false)
@@ -216,16 +233,7 @@ namespace CustomNotes.Managers
 
         protected void OnDestroy()
         {
-            if (_gameNoteController != null)
-            {
-                _gameNoteController.didInitEvent.Remove(this);
-                _gameNoteController.noteWasMissedEvent.Remove(this);
-                _gameNoteController.noteWasCutEvent.Remove(this);
-            }
-            if (_customNoteColorNoteVisuals != null)
-            {
-                _customNoteColorNoteVisuals.didInitEvent -= Visuals_DidInit;
-            }
+            DeOrRegisterEvents(false);
         }
 
         public void SetColor(Color color)

--- a/CustomNotes/Managers/CustomNoteManager.cs
+++ b/CustomNotes/Managers/CustomNoteManager.cs
@@ -6,6 +6,7 @@ using System;
 using CustomNotes.Settings.Utilities;
 using IPA.Loader;
 using System.Linq;
+using UnityEngine;
 
 namespace CustomNotes.Managers
 {
@@ -70,7 +71,29 @@ namespace CustomNotes.Managers
 
         public class Flags
         {
-            public event Action onAnyFlagUpdate;
+            public event Action OnAnyFlagUpdate;
+
+            public bool ShouldDisableCustomNote()
+            {
+                return ForceDisable 
+                    || (GhostNotesEnabled && !IsInFirstSet());
+            }
+
+            public bool IsInFirstSet()
+            {
+                if (FirstFrameCount == 0)
+                {
+                    FirstFrameCount = Time.frameCount;
+                    return true;
+                }
+                
+                if (FirstFrameCount != Time.frameCount)
+                {
+                    return false;
+                }
+
+                return true;
+            }
 
             private bool _forceDisable = false;
             public bool ForceDisable {
@@ -78,7 +101,7 @@ namespace CustomNotes.Managers
                 set
                 {
                     _forceDisable = value;
-                    onAnyFlagUpdate?.Invoke();
+                    OnAnyFlagUpdate?.Invoke();
                 }
             }
 
@@ -88,7 +111,7 @@ namespace CustomNotes.Managers
                 set
                 {
                     _ghostNotesEnabled = value;
-                    onAnyFlagUpdate?.Invoke();
+                    OnAnyFlagUpdate?.Invoke();
                 }
             }
 
@@ -98,7 +121,7 @@ namespace CustomNotes.Managers
                 set
                 {
                     _firstFrameCount = value;
-                    onAnyFlagUpdate?.Invoke();
+                    OnAnyFlagUpdate?.Invoke();
                 }
             }
         }

--- a/CustomNotes/Managers/GameCameraManager.cs
+++ b/CustomNotes/Managers/GameCameraManager.cs
@@ -12,21 +12,33 @@ namespace CustomNotes.Managers
         public Camera MainCamera { get; private set; } = null;
 
         private PluginConfig _pluginConfig;
+        private CustomNoteManager.Flags _customNoteFlags;
 
         [Inject]
-        internal GameCameraManager(PluginConfig pluginConfig)
+        internal GameCameraManager(PluginConfig pluginConfig, CustomNoteManager.Flags customNoteFlags)
         {
             _pluginConfig = pluginConfig;
+            _customNoteFlags = customNoteFlags;
         }
 
         public void Initialize()
         {
             Logger.log.Debug($"Initializing {nameof(GameCameraManager)}!");
+            _customNoteFlags.onAnyFlagUpdate += _customNoteFlags_onAnyFlagUpdate;
             MainCamera = Camera.main;
             if (_pluginConfig.HMDOnly || LayerUtils.HMDOverride)
             {
                 LayerUtils.CreateWatermark();
                 LayerUtils.SetCamera(MainCamera, LayerUtils.CameraView.FirstPerson);
+            }
+        }
+
+        private void _customNoteFlags_onAnyFlagUpdate()
+        {
+            if(_customNoteFlags.ForceDisable || _customNoteFlags.GhostNotesEnabled)
+            {
+                _customNoteFlags.onAnyFlagUpdate -= _customNoteFlags_onAnyFlagUpdate;
+                Dispose();
             }
         }
 

--- a/CustomNotes/Plugin.cs
+++ b/CustomNotes/Plugin.cs
@@ -24,7 +24,7 @@ namespace CustomNotes
             Logger.log = logger;
             zenjector.OnApp<CustomNotesCoreInstaller>().WithParameters(config.Generated<PluginConfig>());
             zenjector.OnMenu<CustomNotesMenuInstaller>();
-            zenjector.OnGame<CustomNotesGameInstaller>(false).ShortCircuitForTutorial();
+            zenjector.OnGame<CustomNotesGameInstaller>(false).ShortCircuitForTutorial().Expose<MainCamera>();
         }
 
         [OnEnable]

--- a/CustomNotes/Settings/UI/NoteDetailsViewController.cs
+++ b/CustomNotes/Settings/UI/NoteDetailsViewController.cs
@@ -21,10 +21,16 @@ namespace CustomNotes.Settings
         public TextPageScrollView noteDescription = null;
 
         [UIComponent("size-slider")]
-        private SliderSetting sizeSlider;
+        private SliderSetting sizeSlider = null;
 
         [UIComponent("hmd-checkbox")]
-        private ToggleSetting hmdCheckbox;
+        private ToggleSetting hmdCheckbox = null;
+
+        [UIComponent("noodle-disable-checkbox")]
+        private ToggleSetting noodleDisableCheckbox = null;
+
+        [UIComponent("modifier-disable-checkbox")]
+        private ToggleSetting modifierDisableCheckbox = null;
 
         public void OnNoteWasChanged(CustomNote customNote)
         {
@@ -44,6 +50,14 @@ namespace CustomNotes.Settings
             if (hmdCheckbox != null)
             {
                 hmdCheckbox.ReceiveValue();
+            }
+            if (noodleDisableCheckbox != null)
+            {
+                noodleDisableCheckbox.ReceiveValue();
+            }
+            if (modifierDisableCheckbox != null)
+            {
+                modifierDisableCheckbox.ReceiveValue();
             }
         }
 
@@ -69,8 +83,21 @@ namespace CustomNotes.Settings
         public bool hmdOnly 
         {
             get { return _pluginConfig.HMDOnly; }
-            set 
-            { _pluginConfig.HMDOnly = value; }
+            set { _pluginConfig.HMDOnly = value; }
+        }
+
+        [UIValue("noodle-disable")]
+        public bool noodleDisable
+        {
+            get { return _pluginConfig.DisableOnNoodle; }
+            set { _pluginConfig.DisableOnNoodle = value; }
+        }
+
+        [UIValue("modifier-disable")]
+        public bool modifierDisable
+        {
+            get { return _pluginConfig.DisableOnModifier; }
+            set { _pluginConfig.DisableOnModifier = value; }
         }
     }
 }

--- a/CustomNotes/Settings/UI/NoteModifierViewController.cs
+++ b/CustomNotes/Settings/UI/NoteModifierViewController.cs
@@ -25,18 +25,18 @@ namespace CustomNotes.Settings.UI
         private List<object> notesList = new List<object>();
 
         [UIComponent("notes-dropdown")]
-        private DropDownListSetting notesDropdown;
+        private DropDownListSetting notesDropdown = null;
 
         [UIComponent("notes-dropdown")]
-        private RectTransform notesDropdownTransform;
+        private RectTransform notesDropdownTransform = null;
 
-        private RectTransform dropdownListTransform;
+        private RectTransform dropdownListTransform = null;
 
         [UIComponent("size-slider")]
-        private SliderSetting sizeSlider;
+        private SliderSetting sizeSlider = null;
 
         [UIComponent("hmd-checkbox")]
-        private ToggleSetting hmdCheckbox;
+        private ToggleSetting hmdCheckbox = null;
 
 
         public NoteModifierViewController(PluginConfig pluginConfig, NoteAssetLoader noteAssetLoader)

--- a/CustomNotes/Settings/UI/Views/noteDetails.bsml
+++ b/CustomNotes/Settings/UI/Views/noteDetails.bsml
@@ -1,4 +1,4 @@
-﻿<bg child-control-height='false' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
+﻿<bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd'>
   <tab-selector tab-tag='new-tab'/>
   <tab tags='new-tab' tab-name='Note Description'>
     <horizontal horizontal-fit='Unconstrained'>
@@ -13,6 +13,8 @@
     
         <slider-setting id='size-slider' text='Note Scale' min='0.4' max='2' increment='0.05' value='note-size' apply-on-change='true' hover-hint='Changes the scale of custom notes. Requires a non-default note to be used.'/>
         <checkbox-setting id='hmd-checkbox' text='HMD Only' value='hmd-only' apply-on-change='true' hover-hint='Only displays custom notes in the headset. A non-default camera such as Smooth Camera, Camera+, or Camera2 is required.'/>
+        <checkbox-setting id='noodle-disable-checkbox' text='Default Notes on Noodle maps' value='noodle-disable' apply-on-change='true' hover-hint='Switches to the default notes on Noodle maps automatically instead of disabling score.'/>
+        <checkbox-setting id='modifier-disable-checkbox' text='Default Notes with incompatible Modifiers' value='modifier-disable' apply-on-change='true' hover-hint='Switches to the default notes if Ghost Notes, Disappearing Arrows or Small Notes modifier is active instead of disabling score.'/>
         
       </vertical>
     </horizontal>

--- a/CustomNotes/Settings/Utilities/PluginConfig.cs
+++ b/CustomNotes/Settings/Utilities/PluginConfig.cs
@@ -7,5 +7,9 @@
         public virtual float NoteSize { get; set; } = 1;
 
         public virtual bool HMDOnly { get; set; } = false;
+
+        public virtual bool DisableOnNoodle { get; set; } = true;
+
+        public virtual bool DisableOnModifier { get; set; } = true;
     }
 }

--- a/CustomNotes/Utilities/LayerUtils.cs
+++ b/CustomNotes/Utilities/LayerUtils.cs
@@ -122,13 +122,19 @@ namespace CustomNotes.Utilities
             SetLayer(_watermarkObject, NoteLayer.ThirdPerson);
         }
 
+        public static void SetWatermarkActive(bool active = true)
+        {
+            if (_watermarkObject == null) return;
+            _watermarkObject.SetActive(active);
+        }
+
         public static void DestroyWatermark()
         {
             if (_watermarkObject == null) return;
             _watermarkObject.SetActive(false);
             UnityEngine.Object.Destroy(_watermarkObject);
             _watermarkObject = null;
-        } 
+        }
 
         /// <summary>
         /// Force custom notes to only be visible in-headset, regardless of the player's settings.

--- a/CustomNotes/Utilities/Utils.cs
+++ b/CustomNotes/Utilities/Utils.cs
@@ -7,6 +7,7 @@ using IPA.Loader;
 using IPA.Utilities;
 using System;
 using CustomNotes.Settings.Utilities;
+using System.Collections;
 
 namespace CustomNotes.Utilities
 {
@@ -292,6 +293,20 @@ namespace CustomNotes.Utilities
                 time = System.DateTime.UtcNow;
             if ((time.Month == 4 && time.Day == 1) || bunbundai) return UnityEngine.Random.Range(0.25f, 1.5f);
             else return config.NoteSize;
+        }
+
+        /// <summary>
+        /// Invoke an action after x amount of time
+        /// </summary>
+        /// <param name="time">Time to wait</param>
+        /// <param name="action">Action to invoke</param>
+        public static IEnumerator DoAfter(float time, Action action)
+        {
+            float targetTime = Time.fixedTime + time;
+            while (targetTime > Time.fixedTime)
+                yield return null;
+            action?.Invoke();
+            yield break;
         }
     }
 }

--- a/CustomNotes/Utilities/Utils.cs
+++ b/CustomNotes/Utilities/Utils.cs
@@ -294,19 +294,5 @@ namespace CustomNotes.Utilities
             if ((time.Month == 4 && time.Day == 1) || bunbundai) return UnityEngine.Random.Range(0.25f, 1.5f);
             else return config.NoteSize;
         }
-
-        /// <summary>
-        /// Invoke an action after x amount of time
-        /// </summary>
-        /// <param name="time">Time to wait</param>
-        /// <param name="action">Action to invoke</param>
-        public static IEnumerator DoAfter(float time, Action action)
-        {
-            float targetTime = Time.fixedTime + time;
-            while (targetTime > Time.fixedTime)
-                yield return null;
-            action?.Invoke();
-            yield break;
-        }
     }
 }


### PR DESCRIPTION
### Added two settings:
* Default Notes on Noodle maps
* Default Notes with incompatible Modifiers

### Instead of disabling score ...
* the first setting disables Custom Notes & Bombs on Noodle maps entirely.
* the second setting disables Custom Notes & Bombs if Disappearing Arrows or Small Notes is enabled and only shows Custom Notes for the first set of notes if Ghost Notes is enabled (like the Vanilla game does).

I didn't add those two to the modifier tab though because those are more of a one-and-done type of setting.
The second setting could be removed and set as the default behavior but I'd like some input on that first.

I tested everything with HMDOnly enabled / disabled and all combinations of (affected) modifiers.