### PR TITLE
Update for v1.34.2 beat saber

### DIFF
--- a/CustomNotes/CustomNotes.csproj
+++ b/CustomNotes/CustomNotes.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CustomNotes</RootNamespace>
     <AssemblyName>CustomNotes</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -37,9 +38,24 @@
       <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="AssetBundleLoadingTools, Version=1.1.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Plugins\AssetBundleLoadingTools.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="BeatmapCore">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatmapCore.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="BGLib.DotnetExtension, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.DotnetExtension.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="BGLib.UnityExtension, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.UnityExtension.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="BSML">
       <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
@@ -162,6 +178,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings\UI\NoteListViewController.cs" />
     <Compile Include="Managers\NoteAssetLoader.cs" />
+    <Compile Include="Utilities\CustomNoteAssetLoader.cs" />
     <Compile Include="Utilities\Utils.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/CustomNotes/Data/CustomNote.cs
+++ b/CustomNotes/Data/CustomNote.cs
@@ -129,7 +129,7 @@ namespace CustomNotes.Data
                 try
                 {
                     AssetBundle = AssetBundle.LoadFromMemory(noteObject);
-                    GameObject note = AssetBundle.LoadAsset<GameObject>("assets/_customnote.prefab");
+                    GameObject note = CustomNoteAssetLoader.LoadNoteWithRepair(AssetBundle, name);
                     FileName = $@"internalResource\{name}";
 
                     Descriptor = note.GetComponent<NoteDescriptor>();

--- a/CustomNotes/Data/CustomNote.cs
+++ b/CustomNotes/Data/CustomNote.cs
@@ -32,8 +32,10 @@ namespace CustomNotes.Data
             {
                 try
                 {
-                    AssetBundle = AssetBundle.LoadFromFile(Path.Combine(Plugin.PluginAssetPath, fileName));
-                    GameObject note = AssetBundle.LoadAsset<GameObject>("assets/_customnote.prefab");
+                    string filePath = Path.Combine(Plugin.PluginAssetPath, fileName);
+
+                    AssetBundle = AssetBundle.LoadFromFile(filePath);
+                    GameObject note = CustomNoteAssetLoader.LoadNoteWithRepair(AssetBundle, fileName);
 
                     Descriptor = note.GetComponent<NoteDescriptor>();
                     Descriptor.Icon = Descriptor.Icon ?? Utils.GetDefaultCustomIcon();

--- a/CustomNotes/Managers/CustomBurstSliderController.cs
+++ b/CustomNotes/Managers/CustomBurstSliderController.cs
@@ -27,7 +27,7 @@ namespace CustomNotes.Managers
 
         public Color Color
         {
-            get => _customNoteColorNoteVisuals != null ? _customNoteColorNoteVisuals.noteColor : Color.white;
+            get => _customNoteColorNoteVisuals != null ? _customNoteColorNoteVisuals.NoteColor : Color.white;
             set => SetColor(value);
         }
 
@@ -132,7 +132,7 @@ namespace CustomNotes.Managers
 
         private void Visuals_DidInit(ColorNoteVisuals visuals, NoteControllerBase noteController)
         {
-            SetActiveThenColor(activeNote, (visuals as CustomNoteColorNoteVisuals).noteColor);
+            SetActiveThenColor(activeNote, (visuals as CustomNoteColorNoteVisuals).NoteColor);
             // Hide certain parts of the default note which is not required
             if (_pluginConfig.HMDOnly == false && LayerUtils.HMDOverride == false)
             {

--- a/CustomNotes/Managers/CustomNoteController.cs
+++ b/CustomNotes/Managers/CustomNoteController.cs
@@ -33,7 +33,7 @@ namespace CustomNotes.Managers
 
         public Color Color
         {
-            get => _customNoteColorNoteVisuals != null ? _customNoteColorNoteVisuals.noteColor : Color.white;
+            get => _customNoteColorNoteVisuals != null ? _customNoteColorNoteVisuals.NoteColor : Color.white;
             set => SetColor(value);
         }
 
@@ -161,7 +161,7 @@ namespace CustomNotes.Managers
 
         private void Visuals_DidInit(ColorNoteVisuals visuals, NoteControllerBase noteController)
         {
-            SetActiveThenColor(activeNote, (visuals as CustomNoteColorNoteVisuals).noteColor);
+            SetActiveThenColor(activeNote, (visuals as CustomNoteColorNoteVisuals).NoteColor);
             // Hide certain parts of the default note which is not required
             if (_pluginConfig.HMDOnly == false && LayerUtils.HMDOverride == false)
             {

--- a/CustomNotes/Managers/MenuButtonManager.cs
+++ b/CustomNotes/Managers/MenuButtonManager.cs
@@ -26,10 +26,7 @@ namespace CustomNotes.Managers
 
         public void Dispose()
         {
-            if (MenuButtons.IsSingletonAvailable)
-            {
-                MenuButtons.instance.UnregisterButton(_menuButton);
-            }
+            MenuButtons.instance.UnregisterButton(_menuButton);
         }
 
         private void ShowNotesFlow()

--- a/CustomNotes/Overrides/CustomNoteColorNoteVisuals.cs
+++ b/CustomNotes/Overrides/CustomNoteColorNoteVisuals.cs
@@ -1,4 +1,5 @@
 ﻿using CustomNotes.Utilities;
+using IPA.Utilities;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -6,19 +7,34 @@ namespace CustomNotes.Overrides
 {
     public class CustomNoteColorNoteVisuals : ColorNoteVisuals
     {
-        public Color noteColor
+        public Color NoteColor
         {
-            get { return _noteColor; }
-            set { _noteColor = value; }
+            get { return ReflectionUtil.GetField<Color, ColorNoteVisuals>(this, "_noteColor"); }
+            set { ReflectionUtil.SetField<ColorNoteVisuals, Color>(this, "_noteColor", value); }
         }
 
-        public MeshRenderer[] arrowObjects
+        private MeshRenderer[] ArrowMeshRenderers
+        {
+            get { return ReflectionUtil.GetField<MeshRenderer[], ColorNoteVisuals>(this, "_arrowMeshRenderers"); }
+        }
+
+        private MeshRenderer[] CircleMeshRenderers
+        {
+            get { return ReflectionUtil.GetField<MeshRenderer[], ColorNoteVisuals>(this, "_circleMeshRenderers"); }
+        }
+
+        private MaterialPropertyBlockController[] MaterialPropertyBlockControllers
+        {
+            get { return ReflectionUtil.GetField<MaterialPropertyBlockController[], ColorNoteVisuals>(this, "_materialPropertyBlockControllers"); }
+        }
+
+        public MeshRenderer[] ArrowObjects
         {
             get
             {
                 List<MeshRenderer> arrowObjectList = new List<MeshRenderer>();
-                arrowObjectList.AddRange(_arrowMeshRenderers);
-                arrowObjectList.AddRange(_circleMeshRenderers);
+                arrowObjectList.AddRange(ArrowMeshRenderers);
+                arrowObjectList.AddRange(CircleMeshRenderers);
                 return arrowObjectList.ToArray();
             }
         }
@@ -27,14 +43,15 @@ namespace CustomNotes.Overrides
 
         public void SetColor(Color color, bool updateMaterialBlocks)
         {
-            _noteColor = color;
+            NoteColor = color;
             //_arrowGlowSpriteRenderer.color = _noteColor.ColorWithAlpha(_arrowGlowIntensity);
             //_circleGlowSpriteRenderer.color = _noteColor;
             if (updateMaterialBlocks)
             {
+                MaterialPropertyBlockController[] _materialPropertyBlockControllers = MaterialPropertyBlockControllers;
                 foreach (MaterialPropertyBlockController materialPropertyBlockController in _materialPropertyBlockControllers)
                 {
-                    materialPropertyBlockController.materialPropertyBlock.SetColor(ColorNoteVisuals._colorId, _noteColor.ColorWithAlpha(1f));
+                    materialPropertyBlockController.materialPropertyBlock.SetColor("_Color", ColorExtensions.ColorWithAlpha(color, 1f));
                     materialPropertyBlockController.ApplyChanges();
                 }
             }
@@ -42,7 +59,7 @@ namespace CustomNotes.Overrides
 
         public void TurnOffVisuals()
         {
-            foreach (MeshRenderer arrowRenderer in arrowObjects)
+            foreach (MeshRenderer arrowRenderer in ArrowObjects)
             {
                 arrowRenderer.enabled = false;
             }
@@ -50,7 +67,7 @@ namespace CustomNotes.Overrides
 
         public void SetBaseGameVisualsLayer(int layer)
         {
-            foreach (MeshRenderer arrowRenderer in arrowObjects)
+            foreach (MeshRenderer arrowRenderer in ArrowObjects)
             {
                 arrowRenderer.gameObject.layer = layer;
             }
@@ -59,7 +76,7 @@ namespace CustomNotes.Overrides
         public void CreateFakeVisuals(int layer)
         {
             ClearDuplicatedArrows();
-            foreach (MeshRenderer arrowRenderer in arrowObjects)
+            foreach (MeshRenderer arrowRenderer in ArrowObjects)
             {
                 DuplicateIfExists(arrowRenderer.gameObject, layer);
             }
@@ -68,11 +85,11 @@ namespace CustomNotes.Overrides
         public void CreateAndScaleFakeVisuals(int layer, float scale)
         {
             ClearDuplicatedArrows();
-            foreach (MeshRenderer arrowRenderer in _arrowMeshRenderers)
+            foreach (MeshRenderer arrowRenderer in ArrowMeshRenderers)
             {
                 ScaleIfExists(arrowRenderer.gameObject, layer, scale, new Vector3(0, 0.1f, -0.3f));
             }
-            foreach (MeshRenderer circleRenderer in _circleMeshRenderers)
+            foreach (MeshRenderer circleRenderer in CircleMeshRenderers)
             {
                 ScaleIfExists(circleRenderer.gameObject, layer, scale, new Vector3(0, 0, -0.25f));
             }
@@ -82,7 +99,7 @@ namespace CustomNotes.Overrides
         {
             Vector3 scaleVector = new Vector3(1, 1, 1) * scale;
 
-            foreach (MeshRenderer arrowRenderer in _arrowMeshRenderers)
+            foreach (MeshRenderer arrowRenderer in ArrowMeshRenderers)
             {
                 if (arrowRenderer.gameObject.name == "NoteArrowGlow") arrowRenderer.gameObject.transform.localScale = new Vector3(0.6f, 0.3f, 0.6f) * scale;
                 else arrowRenderer.gameObject.transform.localScale = scaleVector;
@@ -90,7 +107,7 @@ namespace CustomNotes.Overrides
                 arrowRenderer.gameObject.transform.localPosition = new Vector3(0, 0.1f, -0.3f) * scale;
             }
 
-            foreach (MeshRenderer circleRenderer in _circleMeshRenderers)
+            foreach (MeshRenderer circleRenderer in CircleMeshRenderers)
             {
                 circleRenderer.gameObject.transform.localScale = scaleVector / 2;
                 circleRenderer.gameObject.transform.localPosition = new Vector3(0, 0, -0.3f) * scale;

--- a/CustomNotes/Properties/AssemblyInfo.cs
+++ b/CustomNotes/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.6.1")]
-[assembly: AssemblyFileVersion("2.6.1")]
+[assembly: AssemblyVersion("2.6.2")]
+[assembly: AssemblyFileVersion("2.6.2")]

--- a/CustomNotes/Properties/AssemblyInfo.cs
+++ b/CustomNotes/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.6.2")]
-[assembly: AssemblyFileVersion("2.6.2")]
+[assembly: AssemblyVersion("2.6.3")]
+[assembly: AssemblyFileVersion("2.6.3")]

--- a/CustomNotes/Settings/UI/NoteModifierViewController.cs
+++ b/CustomNotes/Settings/UI/NoteModifierViewController.cs
@@ -44,8 +44,7 @@ namespace CustomNotes.Settings.UI
 
         public void Dispose()
         {
-            if (GameplaySetup.IsSingletonAvailable && BSMLParser.IsSingletonAvailable)
-                GameplaySetup.instance.RemoveTab("Custom Notes");
+            GameplaySetup.instance.RemoveTab("Custom Notes");
         }
 
         internal void ParentControllerActivated()

--- a/CustomNotes/Utilities/CustomNoteAssetLoader.cs
+++ b/CustomNotes/Utilities/CustomNoteAssetLoader.cs
@@ -1,0 +1,55 @@
+﻿using AssetBundleLoadingTools.Utilities;
+using AssetBundleLoadingTools.Models.Shaders;
+using UnityEngine;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection.Emit;
+using System;
+
+namespace CustomNotes.Utilities
+{
+    internal class CustomNoteAssetLoader
+    {
+        public static GameObject LoadNoteObject(AssetBundle bundle)
+        {
+            GameObject noteObject = bundle.LoadAsset<GameObject>("assets/_customnote.prefab");
+            return noteObject;
+        }
+
+        public static GameObject LoadNoteWithRepair(AssetBundle bundle, string fileName)
+        {
+            GameObject noteObject = LoadNoteObject(bundle);
+            noteObject = FixNoteShaders(noteObject, fileName);
+            return noteObject;
+        }
+
+        public static GameObject FixNoteShaders(GameObject noteObject, string fileName)
+        {
+            Logger.log.Debug($"Repairing shaders for {fileName}");
+            try
+            {
+                List<Material> materials = ShaderRepair.GetMaterialsFromGameObjectRenderers(noteObject);
+                var shaderReplacementInfo = ShaderRepair.FixShadersOnMaterials(materials);
+
+                if (shaderReplacementInfo.AllShadersReplaced == false)
+                {
+                    Logger.log.Warn("Missing shader replacement data:");
+                    foreach (var shaderName in shaderReplacementInfo.MissingShaderNames)
+                    {
+                        Logger.log.Warn($"\t- {shaderName}");
+                    }
+                }
+                else
+                {
+                    Logger.log.Debug("All shaders replaced!");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.log.Error($"Problem encountered when attempting shader repair for {fileName}");
+                Logger.log.Error(ex);
+            }
+            return noteObject;
+        } 
+    }
+}

--- a/CustomNotes/Utilities/CustomNoteAssetLoader.cs
+++ b/CustomNotes/Utilities/CustomNoteAssetLoader.cs
@@ -1,9 +1,6 @@
 ﻿using AssetBundleLoadingTools.Utilities;
-using AssetBundleLoadingTools.Models.Shaders;
 using UnityEngine;
 using System.Collections.Generic;
-using System.IO;
-using System.Reflection.Emit;
 using System;
 
 namespace CustomNotes.Utilities

--- a/CustomNotes/manifest.json
+++ b/CustomNotes/manifest.json
@@ -9,7 +9,7 @@
   "icon": "CustomNotes.Resources.Icons.icon.png",
   "id": "Custom Notes",
   "name": "CustomNotes",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "dependsOn": {
     "BSIPA": "^4.2.1",
     "BeatSaberMarkupLanguage": "^1.6.0",

--- a/CustomNotes/manifest.json
+++ b/CustomNotes/manifest.json
@@ -11,11 +11,11 @@
   "name": "CustomNotes",
   "version": "2.6.2",
   "dependsOn": {
-    "BSIPA": "^4.2.1",
-    "BeatSaberMarkupLanguage": "^1.6.0",
-    "SiraUtil": "^3.0.6",
-    "SongCore": "^3.0.0",
-    "CameraUtils": "^1.0.0"
+    "BSIPA": "^4.3.2",
+    "BeatSaberMarkupLanguage": "^1.8.1",
+    "SiraUtil": "^3.1.6",
+    "SongCore": "^3.12.2",
+    "CameraUtils": "^1.0.7"
   },
   "links": {
     "project-home": "https://github.com/legoandmars/BeatSaberCustomNotes",

--- a/CustomNotes/manifest.json
+++ b/CustomNotes/manifest.json
@@ -9,11 +9,12 @@
   "icon": "CustomNotes.Resources.Icons.icon.png",
   "id": "Custom Notes",
   "name": "CustomNotes",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "dependsOn": {
     "BSIPA": "^4.3.2",
     "BeatSaberMarkupLanguage": "^1.8.1",
     "SiraUtil": "^3.1.6",
+    "AssetBundleLoadingTools": "^1.1.3",
     "SongCore": "^3.12.2",
     "CameraUtils": "^1.0.7"
   },


### PR DESCRIPTION
- Switched to ABLT to fix shader rendering in new unity version 
- Fix for `CustomNoteColorNoteVisuals` with inaccessible base class fields in `ColorNoteVisuals`
- `BeatSaberMarkupLanguage@1.8.1`, `SiraUtil@3.1.6`, `BSIPA@4.3.2`, `AssetBundleLoadingTools@1.1.3`

Tested on Beat Saber v1.34.2